### PR TITLE
Add Dockerfile to build termite in an ubuntu container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM	ubuntu:16.04
+
+ARG	http_proxy
+ARG	https_proxy
+
+RUN	apt-get update && \
+	apt-get install -y \
+	build-essential \
+	git \
+	g++ \
+	libgtk-3-dev \
+	gtk-doc-tools \
+	gnutls-bin \
+	valac \
+	intltool \
+	libpcre2-dev \
+	libglib3.0-cil-dev \
+	libgnutls28-dev \
+	libgirepository1.0-dev \
+	libxml2-utils \
+	gperf
+
+RUN	git clone https://github.com/thestinger/termite.git && \
+	rm -rf termite/util && \
+	git clone https://github.com/thestinger/util.git termite/util
+RUN	git clone https://github.com/thestinger/vte-ng.git
+
+#export LIBRARY_PATH="/usr/include/gtk-3.0:$LIBRARY_PATH"
+RUN	cd vte-ng && ./autogen.sh && make && make install
+RUN	cd ../termite && make
+
+VOLUME	/target
+ENTRYPOINT ["cp", "termite/termite", "/target/"]
+
+## to get termite, you can build and run this container:
+# docker build -t termite-install .
+# docker run --rm -it -v $(pwd):/target termite-install
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN	cd vte-ng && ./autogen.sh && make && make install
 RUN	cd ../termite && make
 
 VOLUME	/target
-ENTRYPOINT ["cp", "termite/termite", "/target/"]
+ENTRYPOINT ["cp", "termite/termite", "termite/termite.desktop", "termite/termite.terminfo", "/target/"]
 
 ## to get termite, you can build and run this container:
 # docker build -t termite-install .


### PR DESCRIPTION
I got in the habit of building software in containers to not mess with my desktop machine. I wanted to give *termite* a try, but couldn't find any ubuntu packages to install, so I decided to write a simple *Dockerfile* to build the application.

I heavily reused your installation script, so I thought your repository would be a good place for the *Dockerfile* as well. If you don't want this in your repository, please let me know and I'll keep my own fork with the file.