### PR TITLE
Added missing libtool dependency.

### DIFF
--- a/termite-install.sh
+++ b/termite-install.sh
@@ -13,6 +13,7 @@ sudo apt-get install -y \
 	libgnutls28-dev \
 	libgirepository1.0-dev \
 	libxml2-utils \
+	libtool\
 	gperf
 	
 git clone --recursive https://github.com/thestinger/termite.git


### PR DESCRIPTION
Missing libtool dependency leads to failure in building vte-2.9, hence breaking this script.